### PR TITLE
Allow classes that extend Sailthru Client to access the API connection details

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -13,28 +13,28 @@ class Sailthru_Client {
      * Sailthru API Key
      * @var string
      */
-    private $api_key;
+    protected $api_key;
 
     /**
      *
      * Sailthru Secret
      * @var string
      */
-    private $secret;
+    protected $secret;
 
     /**
      *
      * Sailthru API URL, can be different for different users according to their settings
      * @var string
      */
-    private $api_uri = 'https://api.sailthru.com';
+    protected $api_uri = 'https://api.sailthru.com';
 
     /**
      *
      * cURL or non-cURL request
      * @var string
      */
-    private $http_request_type;
+    protected $http_request_type;
 
     /**
      *


### PR DESCRIPTION
We make heavy use of the Sailthru_Client class but we have been asked to implement custom error catching and reporting. This is being done by extending the Sailthru_Client class and wrapping the httpRequest function in our own. I plan to put these improvements into https://drupal.org/project/sailthru_client too.

One issue with this is we have to redeclare the private variables the class has. It would be great if we could access then when we extend the class instead of redeclaring and it'll make it safer to keep upgraded.

Thanks again for a great client and taking time to review our pull requests :)
