### PR TITLE
Fix to apiGet() for parameterless calls (eg: getTemplates, getLists)

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -428,7 +428,7 @@ class Sailthru_Client {
      * @link http://docs.sailthru.com/api/template
      */
     public function getTemplates() {
-        return $this->apiGet('template', array());
+        return $this->apiGet('template');
     }
 
 
@@ -1222,7 +1222,7 @@ class Sailthru_Client {
      * @param array $data
      * @return array
      */
-    public function apiGet($action, $data, $method = 'GET') {
+    public function apiGet($action, $data = array(), $method = 'GET') {
         return $this->httpRequest("{$this->api_uri}/{$action}", $this->prepareJsonPayload($data), $method);
     }
 


### PR DESCRIPTION
I encountered a PHP error when using getLists().  It passes a single param, the str 'list', to apiGet() however this function expects a min of 2 params.

I've chosen to modify apiGet() to default $data to an empty arr, although the same could've been done as per the original getTemplates() method - which just passes an empty arr.
