### PR TITLE
Allow passing of optional parameters when calling Sailthru_Client::getEmail()

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -162,10 +162,11 @@ class Sailthru_Client {
      * Return information about an email address, including replacement vars and lists.
      *
      * @param string $email
+     * @param array $options
      * @link http://docs.sailthru.com/api/email
      */
-    public function getEmail($email) {
-        return $this->apiGet('email', array('email' => $email));
+    public function getEmail($email, array $options = array()) {
+        return $this->apiGet('email', array_merge(array('email' => $email), $options));
     }
 
 


### PR DESCRIPTION
This PR adds the ability to pass optional parameters (such as `recent_sends` or `recent_blasts`) to the `Sailthru_Client::getEmail()` method.
