### PR TITLE
Remove createNewUser()

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1070,15 +1070,6 @@ class Sailthru_Client {
 
 
     /**
-     * Creates new user
-     * @param Array $options
-     */
-    public function createNewUser(array $options = array()) {
-        unset($options['id']);
-        return $this->apiPost('user', $options);
-    }
-
-    /**
      * Get user by Sailthru ID
      * @param String $id
      * @param Array $fields


### PR DESCRIPTION
is redundant with saveUser, and creates phantom users when using the POST user call the way it was designed
