### PR TITLE
PHP 5.5 Check. Use CURLFile instead of @filename API

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1438,7 +1438,7 @@ class Sailthru_Client {
         if (!empty ($binary_data_param)) {
             foreach ($binary_data_param as $param) {
                 if (isset($data[$param]) && file_exists($data[$param])) {
-                    $binary_data[$param] = version_compare(PHP_VERSION, '5.5.0') >= 0
+                    $binary_data[$param] = version_compare(PHP_VERSION, '5.5.0') >= 0 && class_exists('CURLFile')
                         ? new CURLFile($data[$param])
                         : "@{$data[$param]}";
                     unset($data[$param]);


### PR DESCRIPTION
Fixes the following error when using PHP 5.5 or greater

Deprecated: curl_setopt(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead.
