### PR TITLE
fix broken apiDelete call introduced in f8172eaf75a97498972809c7ce500079...

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1479,7 +1479,7 @@ class Sailthru_Client {
      * @param array $data
      * @return array
      */
-    public function apiDelete($action, $data, $options) {
+    public function apiDelete($action, $data, $options = array()) {
         return $this->apiGet($action, $data, 'DELETE', $options);
     }
 


### PR DESCRIPTION
The addition of the $options array, as a required parameter to the signature in apiDelete (https://github.com/sailthru/sailthru-php5-client/pull/42/files#diff-a23c1d90a12794a71a2a3ec5a3f9df5cR1482) broken all delete calls. (cancelSend, deleteAlert, deleteBlast, deleteList, deleteTemplate)

The $options array should be optional as per apiGet.
