### PR TITLE
Set SSL version

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1371,6 +1371,8 @@ class Sailthru_Client {
         curl_setopt($ch, CURLOPT_TIMEOUT_MS, $options['timeout']);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $options['connect_timeout']);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        
+        curl_setopt($ch, CURLOPT_SSLVERSION, 3);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->httpHeaders);
         $data = curl_exec($ch);


### PR DESCRIPTION
Set SSL version number for older PHP setups where it is not detected
automatically.
