### PR TITLE
Fix link to PHP5 library docs on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ sailthru-php5-client
 ====================
 
 For installation instructions, documentation, and examples please visit:
-[http://getstarted.sailthru.com/developers/api-libraries/php](http://getstarted.sailthru.com/developers/api-libraries/php)
+[http://getstarted.sailthru.com/new-for-developers-overview/api-client-library/php5/](http://getstarted.sailthru.com/new-for-developers-overview/api-client-library/php5/)
 
 A simple client library to remotely access the `Sailthru REST API` as per [http://getstarted.sailthru.com/developers/api](http://getstarted.sailthru.com/developers/api)
 


### PR DESCRIPTION
The current link in the README (and thus the root of the github page) leads to a 404. This appears to be the right url.