### PR TITLE
The isset check needs to be !empty

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1515,7 +1515,7 @@ class Sailthru_Client {
                 Sailthru_Client_Exception::CODE_RESPONSE_INVALID
             );
         }
-        if (!empty($json['error'])) {
+        if (isset($json['error'])) {
             throw new Sailthru_Client_Exception($json['errormsg'], $json['error']);
         }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1515,7 +1515,7 @@ class Sailthru_Client {
                 Sailthru_Client_Exception::CODE_RESPONSE_INVALID
             );
         }
-        if (isset($json['error'])) {
+        if (!empty($json['error'])) {
             throw new Sailthru_Client_Exception($json['errormsg'], $json['error']);
         }
 


### PR DESCRIPTION
The `isset` check fails when `$json['error']` is set to `false`, which is sometimes the case.