### PR TITLE
Changing Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 php:
   - 5.4


### PR DESCRIPTION
The Travis image we were using lost support for HHVM. This should allow us to properly test HHVM again.