### PR TITLE
Remove Email API Helpers

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -179,71 +179,7 @@ class Sailthru_Client {
     public function cancelSend($send_id) {
         return $this->apiDelete('send', [ 'send_id' => $send_id ]);
     }
-
-    /**
-     * Return information about an email address, including replacement vars and lists.
-     *
-     * @param string $email
-     * @param array $options
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function getEmail($email, array $options = [ ]) {
-        return $this->apiGet('email', array_merge([ 'email' => $email ], $options));
-    }
-
-    /**
-     * Set replacement vars and/or list subscriptions for an email address.
-     *
-     * $lists should be an assoc array mapping list name => 1 for subscribed, 0 for unsubscribed
-     *
-     * @param string $email
-     * @param array $vars
-     * @param array $lists
-     * @param array $templates
-     * @param integer $verified 1 or 0
-     * @param string $optout
-     * @param string $send
-     * @param array $send_vars
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function setEmail($email, $vars = [ ], $lists = [ ], $templates = [ ], $verified = 0, $optout = null, $send = null, $send_vars = [ ]) {
-        $data = [ 'email' => $email ];
-        if ($vars) {
-            $data['vars'] = $vars;
-        }
-        if ($lists) {
-            $data['lists'] = $lists;
-        }
-        if ($templates) {
-            $data['templates'] = $templates;
-        }
-        $data['verified'] = (int) $verified;
-        if ($optout !== null) {
-            $data['optout'] = $optout;
-        }
-        if ($send !== null) {
-            $data['send'] = $send;
-        }
-        if (!empty($send_vars)) {
-            $data['send_vars'] = $send_vars;
-        }
-
-        return $this->apiPost('email', $data);
-    }
-
-    /**
-     * Update / add email address
-     *
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function setEmail2($email, array $options = [ ]) {
-        $options['email'] = $email;
-        return $this->apiPost('email', $options);
-    }
-
+    
     /**
      * Schedule a mass mail blast
      *

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -179,7 +179,7 @@ class Sailthru_Client {
     public function cancelSend($send_id) {
         return $this->apiDelete('send', [ 'send_id' => $send_id ]);
     }
-    
+
     /**
      * Schedule a mass mail blast
      *
@@ -1025,24 +1025,18 @@ class Sailthru_Client {
     }
 
     /**
-     * Save existing user
-     * @param String $id
+     * Get user by email or Sailthru ID
+     * @param string $id | email or sailthru ID
+     * @param array $fields
      * @param array $options
      * @return array
      */
-    public function saveUser($id, array $options = [ ]) {
-        $data = $options;
-        $data['id'] = $id;
-        return $this->apiPost('user', $data);
-    }
-
-    /**
-     * Get user by Sailthru ID
-     * @param String $id
-     * @return array
-     */
-    public function getUserBySid($id) {
-        return $this->apiGet('user', [ 'id' => $id ]);
+    public function getUser($id, $fields = [ ], $options = [ ]) {
+        $options["id"] = $id;
+        if (!empty($fields)) {
+            $options['fields'] = $fields;
+        }
+        return $this->apiGet("user", $options);
     }
 
     /**
@@ -1050,17 +1044,14 @@ class Sailthru_Client {
      * @param String $id
      * @param String $key
      * @param array $fields
+     * @param array options
      * @return array
      */
-    public function getUserByKey($id, $key, array $fields = [ ]) {
-        $data = [
-            'id' => $id,
-            'key' => $key,
-            'fields' => $fields
-        ];
-        return $this->apiGet('user', $data);
+    public function getUserByKey($id, $key, $fields = [ ], $options = [ ]) {
+        $options["key"] = $key;
+        return $this->getUser($id, $fields, $options);
     }
-
+    
     /**
      *
      * Set Horizon cookie

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -9,6 +9,6 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $api_secret = "invalid_secret";
         $api_url = "https://api.invalid_url.com";
         $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
-        $sailthruClient->getEmail("praj@sailthru.com");
+        $sailthruClient->getUser("praj@sailthru.com");
     }
 }


### PR DESCRIPTION
The Email API has been deprecated. This creates a new `getUser` function to replace getEmail, and refactors the other User API helper to use `getUser`.