### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sailthru-php5-client
-A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
-
 [![Build Status](https://travis-ci.org/sailthru/sailthru-php5-client.svg?branch=master)](https://travis-ci.org/sailthru/sailthru-php5-client)
 [![Coverage Status](https://coveralls.io/repos/github/sailthru/sailthru-php5-client/badge.svg?branch=master)](https://coveralls.io/github/sailthru/sailthru-php5-client?branch=master)
+
+A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
 
 ### Documentation
 
@@ -16,6 +16,9 @@ A simple client library to remotely access the `Sailthru REST API`. By default, 
 You can clone via GitHub or install via composer.
 ```shell
 git clone git@github.com:sailthru/sailthru-php5-client.git
+```
+or
+```shell
 composer require sailthru/sailthru-php5-client
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ A simple client library to remotely access the `Sailthru REST API`. By default, 
 
 ### Documentation
 
-[REST API Documentation](https://getstarted.sailthru.com/developers/api-basics/introduction/)
-[PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
+[API Documentation][1]
+[PHP5 Client Documentation][2]
+
+Deeper looks:
+[API Responses and Error Codes][3]
+[Rate Limiting][4]
 
 ###  Installation
 
@@ -28,10 +32,10 @@ For basic usage, you can initialize with just API Key and Secret
     $client = new Sailthru_Client($api_key, $api_secret);
 ```
 
-### Exception-handling
+### Exception Handling
 As of 2.0.0, the client library will throw a `Sailthru_Client_Exception` on API and IO errors, which should be properly handled. 
 
-Error codes 1000, 1001, 10002 are client and IO-related, while 0-99 and XX are API errors. [Learn more about our API Errors](https://getstarted.sailthru.com/developers/api-basics/responses/).
+Error codes 1000, 1001, 10002 are IO-related, while 0-99 and XX are [API errors][2].
 ```php
 try { 
     $client->apiPost('user', [..]);
@@ -50,7 +54,7 @@ $client = new Sailthru_Client($this->api_key, $this->secret, $this->api_url, arr
 
 ### API Rate Limiting
 
-Here is an example how to check rate limiting and throttle API calls based on that. For more information about Rate Limiting, see [Sailthru Documentation](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)
+Below shows an example of how to check for Sailthru API rate limiting and throttle requests based on that information. 
 
 ```php
 // get last rate limit info
@@ -83,3 +87,7 @@ vendor/bin/phpunit
 ```
 
 
+[1](https://getstarted.sailthru.com/developers/api-basics/introduction/)
+[2](https://getstarted.sailthru.com/developers/api-client/php5/)
+[3](https://getstarted.sailthru.com/developers/api-basics/responses/)
+[4](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
 
-### Documentation
+## Documentation
 
 * [PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
 * [API Basics](https://getstarted.sailthru.com/developers/api-basics/introduction/)
@@ -12,7 +12,7 @@ A simple client library to remotely access the `Sailthru REST API`. By default, 
 * [Rate Limiting for Requests](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting) 
 
 
-###  Installation
+##  Installation
 
 You can clone via GitHub or install via composer.
 ```shell
@@ -23,7 +23,7 @@ or
 composer require sailthru/sailthru-php5-client
 ```
 
-## Examples 
+### Usage
 
 ### Default initialization
 For basic usage, you can initialize with just API Key and Secret

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A simple client library to remotely access the `Sailthru REST API`. By default, 
 
 ### Documentation
 
-[PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
-[API Basics](https://getstarted.sailthru.com/developers/api-basics/introduction/)
-[API Responses and Error Codes](https://getstarted.sailthru.com/developers/api-basics/responses/)
-[Rate Limiting for Requests](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)
+* [PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
+* [API Basics](https://getstarted.sailthru.com/developers/api-basics/introduction/)
+* [API Responses and Error Codes](https://getstarted.sailthru.com/developers/api-basics/responses/)
+* [Rate Limiting for Requests](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting) 
+
 
 ###  Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or
 composer require sailthru/sailthru-php5-client
 ```
 
-### Usage
+## Usage
 
 ### Default initialization
 For basic usage, you can initialize with just API Key and Secret

--- a/README.md
+++ b/README.md
@@ -1,26 +1,56 @@
-sailthru-php5-client
-====================
+# sailthru-php5-client
 
 [![Build Status](https://travis-ci.org/sailthru/sailthru-php5-client.svg?branch=master)](https://travis-ci.org/sailthru/sailthru-php5-client)
 [![Coverage Status](https://coveralls.io/repos/github/sailthru/sailthru-php5-client/badge.svg?branch=master)](https://coveralls.io/github/sailthru/sailthru-php5-client?branch=master)
 
-For installation instructions, documentation, and examples please visit:
-[http://getstarted.sailthru.com/new-for-developers-overview/api-client-library/php5](http://getstarted.sailthru.com/new-for-developers-overview/api-client-library/php5)
 
-A simple client library to remotely access the `Sailthru REST API` as per [http://getstarted.sailthru.com/developers/api](http://getstarted.sailthru.com/developers/api)
+## About
+A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
 
-By default, it will make request in `JSON` format.
+### Documentation
 
-## Optional parameters for connection/read timeout settings
+[REST API Documentation](https://getstarted.sailthru.com/developers/api-basics/introduction/)
+[PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
 
+###  Installation
+
+You can clone via GitHub or install via composer.
+```shell
+git clone git@github.com:sailthru/sailthru-php5-client.git
+composer require sailthru/sailthru-php5-client
+```
+
+## Examples 
+
+### Default initialization
+For basic usage, you can initialize with just API Key and Secret
+```php
+    $client = new Sailthru_Client($api_key, $api_secret);
+```
+
+### Exception-handling
+As of 2.0.0, the client library will throw a `Sailthru_Client_Exception` on API and IO errors, which should be properly handled. 
+
+Error codes 1000, 1001, 10002 are client and IO-related, while 0-99 and XX are API errors. [Learn more about our API Errors](https://getstarted.sailthru.com/developers/api-basics/responses/).
+```php
+try { 
+    $client->apiPost('user', [..]);
+} catch (Sailthru_Client_Exception $e) {
+    $code = $e->getCode();
+    $message = $->getMessage();
+    // process error
+}
+```
+
+### Optional parameters for connection/read timeout settings
 Increase timeout from 10 (default) to 30 seconds.
+```php
+$client = new Sailthru_Client($this->api_key, $this->secret, $this->api_url, array('timeout' => 30000, 'connect_timeout' => 30000));
+```
 
-    $client = new Sailthru_Client($this->api_key, $this->secret, $this->api_url, array('timeout' => 30000, 'connect_timeout' => 30000));
-
-## API Rate Limiting
+### API Rate Limiting
 
 Here is an example how to check rate limiting and throttle API calls based on that. For more information about Rate Limiting, see [Sailthru Documentation](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)
-
 
 ```php
 // get last rate limit info
@@ -44,9 +74,11 @@ if ($rate_limit_info) {
 
 ## Tests
 
-You can run the tests locally with:
+You can run the tests locally with composer and phpunit:
 
 ```shell
+cd sailthru-php5-client
+composer install
 vendor/bin/phpunit
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 # sailthru-php5-client
+A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
 
 [![Build Status](https://travis-ci.org/sailthru/sailthru-php5-client.svg?branch=master)](https://travis-ci.org/sailthru/sailthru-php5-client)
 [![Coverage Status](https://coveralls.io/repos/github/sailthru/sailthru-php5-client/badge.svg?branch=master)](https://coveralls.io/github/sailthru/sailthru-php5-client?branch=master)
 
-
-## About
-A simple client library to remotely access the `Sailthru REST API`. By default, it will make requests in `JSON` format.
-
 ### Documentation
 
-[API Documentation][1]
-[PHP5 Client Documentation][2]
-
-Deeper looks:
-[API Responses and Error Codes][3]
-[Rate Limiting][4]
+[PHP5 Client Documentation](https://getstarted.sailthru.com/developers/api-client/php5/)
+[API Basics](https://getstarted.sailthru.com/developers/api-basics/introduction/)
+[API Responses and Error Codes](https://getstarted.sailthru.com/developers/api-basics/responses/)
+[Rate Limiting for Requests](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)
 
 ###  Installation
 
@@ -35,7 +30,7 @@ For basic usage, you can initialize with just API Key and Secret
 ### Exception Handling
 As of 2.0.0, the client library will throw a `Sailthru_Client_Exception` on API and IO errors, which should be properly handled. 
 
-Error codes 1000, 1001, 10002 are IO-related, while 0-99 and XX are [API errors][2].
+Error codes 1000, 1001, 10002 are IO-related, while 0-99 and XX are API errors.
 ```php
 try { 
     $client->apiPost('user', [..]);
@@ -85,9 +80,3 @@ cd sailthru-php5-client
 composer install
 vendor/bin/phpunit
 ```
-
-
-[1](https://getstarted.sailthru.com/developers/api-basics/introduction/)
-[2](https://getstarted.sailthru.com/developers/api-client/php5/)
-[3](https://getstarted.sailthru.com/developers/api-basics/responses/)
-[4](https://getstarted.sailthru.com/new-for-developers-overview/api/api-technical-details/#Rate_Limiting)

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,8 +1443,8 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport: %s', $errorMessage),
-                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+                "Curl error: $errorMessage",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -471,11 +471,20 @@ class Sailthru_Client {
      * Get information about a list.
      *
      * @param string $list
+     * @param bool $get_vars
      * @return array
      * @link http://docs.sailthru.com/api/list
      */
-    public function getList($list) {
-        return $this->apiGet('list', [ 'list' => $list ]);
+    public function getList($list, $get_vars = false) {
+        $data = [
+            'list' => $list
+        ];
+        if ($get_vars) {
+            $data['fields'] = [
+                'vars' => 1
+            ];
+        }
+        return $this->apiGet('list', $data);
     }
 
     /**
@@ -495,18 +504,27 @@ class Sailthru_Client {
      * @param string $type
      * @param bool $primary
      * @param array $query
+     * @param array $vars
      * @return array
      * @link http://docs.sailthru.com/api/list
      * @link http://docs.sailthru.com/api/query
      */
     public function saveList($list, $type = null, $primary = null, $query = [ ], $vars = []) {
         $data = [
-            'list' => $list,
-            'type' => $type,
-            'primary' => $primary ? 1 : 0,
-            'query' => $query,
-            'vars' => $vars,
+            'list' => $list
         ];
+        if ($type) {
+            $data['type'] = $type;
+        }
+        if ($primary === null) {
+            $data['primary'] = $primary ? 1 : 0;
+        }
+        if ($query) {
+            $data['query'] = $query;
+        }
+        if ($vars) {
+            $data['vars'] = $vars;
+        }
         return $this->apiPost('list', $data);
     }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -517,9 +517,6 @@ class Sailthru_Client {
             'query' => $query,
             'vars' => $vars
         ];
-        if ($vars) {
-            $data['vars'] = $vars;
-        }
         return $this->apiPost('list', $data);
     }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -179,71 +179,7 @@ class Sailthru_Client {
     public function cancelSend($send_id) {
         return $this->apiDelete('send', [ 'send_id' => $send_id ]);
     }
-
-    /**
-     * Return information about an email address, including replacement vars and lists.
-     *
-     * @param string $email
-     * @param array $options
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function getEmail($email, array $options = [ ]) {
-        return $this->apiGet('email', array_merge([ 'email' => $email ], $options));
-    }
-
-    /**
-     * Set replacement vars and/or list subscriptions for an email address.
-     *
-     * $lists should be an assoc array mapping list name => 1 for subscribed, 0 for unsubscribed
-     *
-     * @param string $email
-     * @param array $vars
-     * @param array $lists
-     * @param array $templates
-     * @param integer $verified 1 or 0
-     * @param string $optout
-     * @param string $send
-     * @param array $send_vars
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function setEmail($email, $vars = [ ], $lists = [ ], $templates = [ ], $verified = 0, $optout = null, $send = null, $send_vars = [ ]) {
-        $data = [ 'email' => $email ];
-        if ($vars) {
-            $data['vars'] = $vars;
-        }
-        if ($lists) {
-            $data['lists'] = $lists;
-        }
-        if ($templates) {
-            $data['templates'] = $templates;
-        }
-        $data['verified'] = (int) $verified;
-        if ($optout !== null) {
-            $data['optout'] = $optout;
-        }
-        if ($send !== null) {
-            $data['send'] = $send;
-        }
-        if (!empty($send_vars)) {
-            $data['send_vars'] = $send_vars;
-        }
-
-        return $this->apiPost('email', $data);
-    }
-
-    /**
-     * Update / add email address
-     *
-     * @link http://docs.sailthru.com/api/email
-     * @return array API result
-     */
-    public function setEmail2($email, array $options = [ ]) {
-        $options['email'] = $email;
-        return $this->apiPost('email', $options);
-    }
-
+    
     /**
      * Schedule a mass mail blast
      *

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -477,13 +477,9 @@ class Sailthru_Client {
      */
     public function getList($list, $get_vars = false) {
         $data = [
-            'list' => $list
+            'list' => $list,
+            'fields' => [ 'vars' => $get_vars ? 1 : 0 ],
         ];
-        if ($get_vars) {
-            $data['fields'] = [
-                'vars' => 1
-            ];
-        }
         return $this->apiGet('list', $data);
     }
 
@@ -515,8 +511,10 @@ class Sailthru_Client {
             'type' => $type,
             'primary' => $primary ? 1 : 0,
             'query' => $query,
-            'vars' => $vars
         ];
+        if ($vars) {
+            $data['vars'] = $vars;
+        }
         return $this->apiPost('list', $data);
     }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,7 +1443,7 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                sprintf('Error with curl transport: %s', $errorMessage),
                 Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
             );
         }

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -509,19 +509,14 @@ class Sailthru_Client {
      * @link http://docs.sailthru.com/api/list
      * @link http://docs.sailthru.com/api/query
      */
-    public function saveList($list, $type = null, $primary = null, $query = [ ], $vars = []) {
+    public function saveList($list, $type = null, $primary = null, $query = [ ], $vars = [ ]) {
         $data = [
-            'list' => $list
+            'list' => $list,
+            'type' => $type,
+            'primary' => $primary ? 1 : 0,
+            'query' => $query,
+            'vars' => $vars
         ];
-        if ($type) {
-            $data['type'] = $type;
-        }
-        if ($primary === null) {
-            $data['primary'] = $primary ? 1 : 0;
-        }
-        if ($query) {
-            $data['query'] = $query;
-        }
         if ($vars) {
             $data['vars'] = $vars;
         }

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1434,9 +1434,22 @@ class Sailthru_Client {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->httpHeaders);
         $response = curl_exec($ch);
         $this->lastResponseInfo = curl_getinfo($ch);
+
+        // Get the curl error message if there is one
+        $errorMessage = false === $response ? curl_error($ch) : null;
+
         curl_close($ch);
 
+        if (false === $response) {
+            // There's a curl error! throw an exception which gives us some details
+            throw new Sailthru_Client_Exception(
+                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+            );
+        }
+
         if (!$response) {
+            // We have an empty (well, falsey) response for the server, but not a curl error
             throw new Sailthru_Client_Exception(
                 "Bad response received from $url",
                 Sailthru_Client_Exception::CODE_RESPONSE_EMPTY

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1370,16 +1370,8 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                "Curl error: $errorMessage",
+                "Curl error: {$errorMessage}",
                 Sailthru_Client_Exception::CODE_HTTP_ERROR
-            );
-        }
-
-        if (!$response) {
-            // We have an empty (well, falsey) response for the server, but not a curl error
-            throw new Sailthru_Client_Exception(
-                "Bad response received from $url",
-                Sailthru_Client_Exception::CODE_RESPONSE_EMPTY
             );
         }
 
@@ -1423,15 +1415,15 @@ class Sailthru_Client {
         $fp = @fopen($url, 'rb', false, $ctx);
         if (!$fp) {
             throw new Sailthru_Client_Exception(
-                "Unable to open stream: $url",
-                Sailthru_Client_Exception::CODE_GENERAL
+                "Stream error: unable to open stream: {$url}",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
         $response = @stream_get_contents($fp);
         if ($response === false) {
             throw new Sailthru_Client_Exception(
-                "No response received from stream: $url",
-                Sailthru_Client_Exception::CODE_RESPONSE_EMPTY
+                "Stream error: Failed to read from stream: {$url}",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
         return $response;
@@ -1444,17 +1436,17 @@ class Sailthru_Client {
      * @param array $data
      * @param string $method
      * @param array $options
-     * @return string
+     * @return array
      * @throws Sailthru_Client_Exception
      */
     protected function httpRequest($action, $data, $method = 'POST', $options = [ ]) {
         $response = $this->{$this->http_request_type}($action, $data, $method, $options);
         $json = json_decode($response, true);
         if ($json === NULL) {
-            throw new Sailthru_Client_Exception(
-                "Response: {$response} is not a valid JSON",
-                Sailthru_Client_Exception::CODE_RESPONSE_INVALID
-            );
+            $exception_msg = empty($response)
+                ? "Empty response"
+                : "Response: {$response} is not a valid JSON";
+            throw new Sailthru_Client_Exception($exception_msg, Sailthru_Client_Exception::CODE_RESPONSE_INVALID);
         }
         if (!empty($json['error'])) {
             throw new Sailthru_Client_Exception($json['errormsg'], $json['error']);

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -179,7 +179,7 @@ class Sailthru_Client {
     public function cancelSend($send_id) {
         return $this->apiDelete('send', [ 'send_id' => $send_id ]);
     }
-    
+
     /**
      * Schedule a mass mail blast
      *
@@ -1025,24 +1025,18 @@ class Sailthru_Client {
     }
 
     /**
-     * Save existing user
-     * @param String $id
+     * Get user by email or Sailthru ID
+     * @param string $id | email or sailthru ID
+     * @param array $fields
      * @param array $options
      * @return array
      */
-    public function saveUser($id, array $options = [ ]) {
-        $data = $options;
-        $data['id'] = $id;
-        return $this->apiPost('user', $data);
-    }
-
-    /**
-     * Get user by Sailthru ID
-     * @param String $id
-     * @return array
-     */
-    public function getUserBySid($id) {
-        return $this->apiGet('user', [ 'id' => $id ]);
+    public function getUser($id, $fields = [ ], $options = [ ]) {
+        $options["id"] = $id;
+        if (!empty($fields)) {
+            $options['fields'] = $fields;
+        }
+        return $this->apiGet("user", $options);
     }
 
     /**
@@ -1050,17 +1044,14 @@ class Sailthru_Client {
      * @param String $id
      * @param String $key
      * @param array $fields
+     * @param array options
      * @return array
      */
-    public function getUserByKey($id, $key, array $fields = [ ]) {
-        $data = [
-            'id' => $id,
-            'key' => $key,
-            'fields' => $fields
-        ];
-        return $this->apiGet('user', $data);
+    public function getUserByKey($id, $key, $fields = [ ], $options = [ ]) {
+        $options["key"] = $key;
+        return $this->getUser($id, $fields, $options);
     }
-
+    
     /**
      *
      * Set Horizon cookie

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,4 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
+    const CODE_TRANSPORT_ERROR = 1003;
 }

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,5 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
-    const CODE_TRANSPORT_ERROR = 1003;
+    const CODE_HTTP_ERROR = 1003;
 }

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -14,7 +14,6 @@ class Sailthru_Client_Exception extends Exception {
      * Standardized exception codes.
      */
     const CODE_GENERAL = 1000;
-    const CODE_RESPONSE_EMPTY = 1001;
-    const CODE_RESPONSE_INVALID = 1002;
-    const CODE_HTTP_ERROR = 1003;
+    const CODE_RESPONSE_INVALID = 1001;
+    const CODE_HTTP_ERROR = 1002;
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -24,9 +24,10 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $mockHttpType->setAccessible(true);
         $mockHttpType->setValue($sailthruClient, "httpRequestWithoutCurl");
 
+        $expectedExceptionMessage = 'Stream error: ';
         $this->setExpectedException(
             'Sailthru_Client_Exception',
-            'Stream error: ',
+            $expectedExceptionMessage,
             1002
         );
         $sailthruClient->getUser("praj@sailthru.com");
@@ -37,7 +38,6 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');
 
         $expectedExceptionMessage = 'Bad response received from';
-
         $this->setExpectedException(
             'Sailthru_Client_Exception',
             $expectedExceptionMessage,

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport';
+        $expectedExceptionMessage = 'Curl error: ';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -1,14 +1,32 @@
 <?php
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
-    /**
-     * @expectedException Sailthru_Client_Exception
-     */
-    public function testSailthru_Client_Exception() {
+    public function testSailthru_Client_Exception_IsThrownWithCurlError() {
+        $expectedExceptionMessage = 'Error with curl transport from url';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1003
+        );
+
         $api_key = "invalid_key";
         $api_secret = "invalid_secret";
-        $api_url = "https://api.invalid_url.com";
+        $api_url = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
+
         $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
         $sailthruClient->getEmail("praj@sailthru.com");
+    }
+
+    public function testSailthru_Client_Exception_IsThrownWithEmptyResponse() {
+        $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');
+
+        $expectedExceptionMessage = 'Bad response received from';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1002
+        );
     }
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -9,6 +9,6 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $api_secret = "invalid_secret";
         $api_url = "https://api.invalid_url.com";
         $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
-        $sailthruClient->getEmail("praj@sailthru.com");
+        $sailthruClient->getUser("praj@sailthru.com");
     }
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -1,22 +1,37 @@
 <?php
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
+
+    private $api_key = "invalid_key";
+    private $api_secret = "invalid_secret";
+    private $bad_api_uri = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
+
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
         $expectedExceptionMessage = 'Curl error: ';
-
         $this->setExpectedException(
             'Sailthru_Client_Exception',
             $expectedExceptionMessage,
-            1003
+            1002
         );
 
-        $api_key = "invalid_key";
-        $api_secret = "invalid_secret";
-        $api_url = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
-
-        $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
+        $sailthruClient = new Sailthru_Client($this->api_key, $this->api_secret, $this->bad_api_uri);
         $sailthruClient->getUser("praj@sailthru.com");
     }
+
+    public function testSailthru_Client_Exception_IsThrownWithoutCurlError() {
+        $sailthruClient = new Sailthru_Client($this->api_key, $this->api_secret, $this->bad_api_uri);
+        $mockHttpType = new ReflectionProperty("Sailthru_Client", "http_request_type");
+        $mockHttpType->setAccessible(true);
+        $mockHttpType->setValue($sailthruClient, "httpRequestWithoutCurl");
+
+        $this->setExpectedException(
+            'Sailthru_Client_Exception',
+            'Stream error: ',
+            1002
+        );
+        $sailthruClient->getUser("praj@sailthru.com");
+    }
+
 
     public function testSailthru_Client_Exception_IsThrownWithEmptyResponse() {
         $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -5,7 +5,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Error with curl transport from url';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1003
         );
@@ -24,7 +24,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Bad response received from';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1002
         );

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport from url';
+        $expectedExceptionMessage = 'Error with curl transport';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',


### PR DESCRIPTION
* Client throws `Sailthru_Client_Exception` on API errors
* Email API Removed
* New User API function `getUser` added
* Documentation updated
* User API helper functions now will return all fields if none passed
* Resolves #66, returning all fields for `getUserByKey` if the `fields` arg is empty
