### PR TITLE
New exception with curl error

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,8 +1443,8 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport: %s', $errorMessage),
-                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+                "Curl error: $errorMessage",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,7 +1443,7 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                sprintf('Error with curl transport: %s', $errorMessage),
                 Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
             );
         }

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1434,9 +1434,22 @@ class Sailthru_Client {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->httpHeaders);
         $response = curl_exec($ch);
         $this->lastResponseInfo = curl_getinfo($ch);
+
+        // Get the curl error message if there is one
+        $errorMessage = false === $response ? curl_error($ch) : null;
+
         curl_close($ch);
 
+        if (false === $response) {
+            // There's a curl error! throw an exception which gives us some details
+            throw new Sailthru_Client_Exception(
+                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+            );
+        }
+
         if (!$response) {
+            // We have an empty (well, falsey) response for the server, but not a curl error
             throw new Sailthru_Client_Exception(
                 "Bad response received from $url",
                 Sailthru_Client_Exception::CODE_RESPONSE_EMPTY

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,4 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
+    const CODE_TRANSPORT_ERROR = 1003;
 }

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,5 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
-    const CODE_TRANSPORT_ERROR = 1003;
+    const CODE_HTTP_ERROR = 1003;
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport';
+        $expectedExceptionMessage = 'Curl error: ';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -1,14 +1,32 @@
 <?php
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
-    /**
-     * @expectedException Sailthru_Client_Exception
-     */
-    public function testSailthru_Client_Exception() {
+    public function testSailthru_Client_Exception_IsThrownWithCurlError() {
+        $expectedExceptionMessage = 'Error with curl transport from url';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1003
+        );
+
         $api_key = "invalid_key";
         $api_secret = "invalid_secret";
-        $api_url = "https://api.invalid_url.com";
+        $api_url = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
+
         $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
         $sailthruClient->getEmail("praj@sailthru.com");
+    }
+
+    public function testSailthru_Client_Exception_IsThrownWithEmptyResponse() {
+        $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');
+
+        $expectedExceptionMessage = 'Bad response received from';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1002
+        );
     }
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -5,7 +5,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Error with curl transport from url';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1003
         );
@@ -24,7 +24,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Bad response received from';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1002
         );

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport from url';
+        $expectedExceptionMessage = 'Error with curl transport';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',


### PR DESCRIPTION
Throwing an exception with the actual curl error, instead of the generic 'empty response' code.