### PR TITLE
More verbose httpRequest Error Handling

### DIFF
--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,8 +1443,8 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport: %s', $errorMessage),
-                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+                "Curl error: $errorMessage",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
 

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1443,7 +1443,7 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                sprintf('Error with curl transport: %s', $errorMessage),
                 Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
             );
         }

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1434,9 +1434,22 @@ class Sailthru_Client {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->httpHeaders);
         $response = curl_exec($ch);
         $this->lastResponseInfo = curl_getinfo($ch);
+
+        // Get the curl error message if there is one
+        $errorMessage = false === $response ? curl_error($ch) : null;
+
         curl_close($ch);
 
+        if (false === $response) {
+            // There's a curl error! throw an exception which gives us some details
+            throw new Sailthru_Client_Exception(
+                sprintf('Error with curl transport from url %s: %s', $url, $errorMessage),
+                Sailthru_Client_Exception::CODE_TRANSPORT_ERROR
+            );
+        }
+
         if (!$response) {
+            // We have an empty (well, falsey) response for the server, but not a curl error
             throw new Sailthru_Client_Exception(
                 "Bad response received from $url",
                 Sailthru_Client_Exception::CODE_RESPONSE_EMPTY

--- a/sailthru/Sailthru_Client.php
+++ b/sailthru/Sailthru_Client.php
@@ -1370,16 +1370,8 @@ class Sailthru_Client {
         if (false === $response) {
             // There's a curl error! throw an exception which gives us some details
             throw new Sailthru_Client_Exception(
-                "Curl error: $errorMessage",
+                "Curl error: {$errorMessage}",
                 Sailthru_Client_Exception::CODE_HTTP_ERROR
-            );
-        }
-
-        if (!$response) {
-            // We have an empty (well, falsey) response for the server, but not a curl error
-            throw new Sailthru_Client_Exception(
-                "Bad response received from $url",
-                Sailthru_Client_Exception::CODE_RESPONSE_EMPTY
             );
         }
 
@@ -1423,15 +1415,15 @@ class Sailthru_Client {
         $fp = @fopen($url, 'rb', false, $ctx);
         if (!$fp) {
             throw new Sailthru_Client_Exception(
-                "Unable to open stream: $url",
-                Sailthru_Client_Exception::CODE_GENERAL
+                "Stream error: unable to open stream: {$url}",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
         $response = @stream_get_contents($fp);
         if ($response === false) {
             throw new Sailthru_Client_Exception(
-                "No response received from stream: $url",
-                Sailthru_Client_Exception::CODE_RESPONSE_EMPTY
+                "Stream error: Failed to read from stream: {$url}",
+                Sailthru_Client_Exception::CODE_HTTP_ERROR
             );
         }
         return $response;
@@ -1444,17 +1436,17 @@ class Sailthru_Client {
      * @param array $data
      * @param string $method
      * @param array $options
-     * @return string
+     * @return array
      * @throws Sailthru_Client_Exception
      */
     protected function httpRequest($action, $data, $method = 'POST', $options = [ ]) {
         $response = $this->{$this->http_request_type}($action, $data, $method, $options);
         $json = json_decode($response, true);
         if ($json === NULL) {
-            throw new Sailthru_Client_Exception(
-                "Response: {$response} is not a valid JSON",
-                Sailthru_Client_Exception::CODE_RESPONSE_INVALID
-            );
+            $exception_msg = empty($response)
+                ? "Empty response"
+                : "Response: {$response} is not a valid JSON";
+            throw new Sailthru_Client_Exception($exception_msg, Sailthru_Client_Exception::CODE_RESPONSE_INVALID);
         }
         if (!empty($json['error'])) {
             throw new Sailthru_Client_Exception($json['errormsg'], $json['error']);

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,4 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
+    const CODE_TRANSPORT_ERROR = 1003;
 }

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -16,5 +16,5 @@ class Sailthru_Client_Exception extends Exception {
     const CODE_GENERAL = 1000;
     const CODE_RESPONSE_EMPTY = 1001;
     const CODE_RESPONSE_INVALID = 1002;
-    const CODE_TRANSPORT_ERROR = 1003;
+    const CODE_HTTP_ERROR = 1003;
 }

--- a/sailthru/Sailthru_Client_Exception.php
+++ b/sailthru/Sailthru_Client_Exception.php
@@ -14,7 +14,6 @@ class Sailthru_Client_Exception extends Exception {
      * Standardized exception codes.
      */
     const CODE_GENERAL = 1000;
-    const CODE_RESPONSE_EMPTY = 1001;
-    const CODE_RESPONSE_INVALID = 1002;
-    const CODE_HTTP_ERROR = 1003;
+    const CODE_RESPONSE_INVALID = 1001;
+    const CODE_HTTP_ERROR = 1002;
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -24,9 +24,10 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $mockHttpType->setAccessible(true);
         $mockHttpType->setValue($sailthruClient, "httpRequestWithoutCurl");
 
+        $expectedExceptionMessage = 'Stream error: ';
         $this->setExpectedException(
             'Sailthru_Client_Exception',
-            'Stream error: ',
+            $expectedExceptionMessage,
             1002
         );
         $sailthruClient->getUser("praj@sailthru.com");
@@ -37,7 +38,6 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');
 
         $expectedExceptionMessage = 'Bad response received from';
-
         $this->setExpectedException(
             'Sailthru_Client_Exception',
             $expectedExceptionMessage,

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport';
+        $expectedExceptionMessage = 'Curl error: ';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -1,14 +1,32 @@
 <?php
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
-    /**
-     * @expectedException Sailthru_Client_Exception
-     */
-    public function testSailthru_Client_Exception() {
+    public function testSailthru_Client_Exception_IsThrownWithCurlError() {
+        $expectedExceptionMessage = 'Error with curl transport from url';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1003
+        );
+
         $api_key = "invalid_key";
         $api_secret = "invalid_secret";
-        $api_url = "https://api.invalid_url.com";
+        $api_url = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
+
         $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
         $sailthruClient->getEmail("praj@sailthru.com");
+    }
+
+    public function testSailthru_Client_Exception_IsThrownWithEmptyResponse() {
+        $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');
+
+        $expectedExceptionMessage = 'Bad response received from';
+
+        $this->setExpectedException(
+            Sailthru_Client_Exception::class,
+            $expectedExceptionMessage,
+            1002
+        );
     }
 }

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -1,22 +1,37 @@
 <?php
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
+
+    private $api_key = "invalid_key";
+    private $api_secret = "invalid_secret";
+    private $bad_api_uri = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
+
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
         $expectedExceptionMessage = 'Curl error: ';
-
         $this->setExpectedException(
             'Sailthru_Client_Exception',
             $expectedExceptionMessage,
-            1003
+            1002
         );
 
-        $api_key = "invalid_key";
-        $api_secret = "invalid_secret";
-        $api_url = "http://foo.invalid"; // .invalid is reserved as an invalid TLD, see https://en.wikipedia.org/wiki/.invalid
-
-        $sailthruClient = new Sailthru_Client($api_key, $api_secret, $api_url);
+        $sailthruClient = new Sailthru_Client($this->api_key, $this->api_secret, $this->bad_api_uri);
         $sailthruClient->getUser("praj@sailthru.com");
     }
+
+    public function testSailthru_Client_Exception_IsThrownWithoutCurlError() {
+        $sailthruClient = new Sailthru_Client($this->api_key, $this->api_secret, $this->bad_api_uri);
+        $mockHttpType = new ReflectionProperty("Sailthru_Client", "http_request_type");
+        $mockHttpType->setAccessible(true);
+        $mockHttpType->setValue($sailthruClient, "httpRequestWithoutCurl");
+
+        $this->setExpectedException(
+            'Sailthru_Client_Exception',
+            'Stream error: ',
+            1002
+        );
+        $sailthruClient->getUser("praj@sailthru.com");
+    }
+
 
     public function testSailthru_Client_Exception_IsThrownWithEmptyResponse() {
         $this->markTestSkipped('This cannot be tested without either mocking curl or having a public server which returns us an empty response.');

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -5,7 +5,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Error with curl transport from url';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1003
         );
@@ -24,7 +24,7 @@ class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
         $expectedExceptionMessage = 'Bad response received from';
 
         $this->setExpectedException(
-            Sailthru_Client_Exception::class,
+            'Sailthru_Client_Exception',
             $expectedExceptionMessage,
             1002
         );

--- a/tests/Sailthru_Client_ExceptionTest.php
+++ b/tests/Sailthru_Client_ExceptionTest.php
@@ -2,7 +2,7 @@
 
 class Sailthru_Client_ExceptionTest extends PHPUnit_Framework_TestCase {
     public function testSailthru_Client_Exception_IsThrownWithCurlError() {
-        $expectedExceptionMessage = 'Error with curl transport from url';
+        $expectedExceptionMessage = 'Error with curl transport';
 
         $this->setExpectedException(
             'Sailthru_Client_Exception',


### PR DESCRIPTION
* Built off of #78, adding curl error for `httpRequestWithCurl`
* Sailthru_Client_Exception now throws with CODE_RESPONSE_INVALID (1001), CODE_HTTP_ERROR (1002), with room for general errors with error code 1000. This removes `CODE_RESPONSE_EMPTY`
* Adds exception-handling test for `httpRequestWithoutCurl`